### PR TITLE
Fix test_start setting in `Benchmark.basic_task()`

### DIFF
--- a/examples/benchmarks/benchmark.py
+++ b/examples/benchmarks/benchmark.py
@@ -189,7 +189,7 @@ class Benchmark:
             task["dataset"]["kwargs"]["segments"]["train"] = pd.Timestamp(self.train_start), seg[1]
 
         if self.test_start is not None:
-            seg = task["dataset"]["kwargs"]["segments"]["train"]
+            seg = task["dataset"]["kwargs"]["segments"]["test"]
             task["dataset"]["kwargs"]["segments"]["test"] = pd.Timestamp(self.test_start), seg[1]
 
         if self.test_end is not None:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
`seg` should be set to be `task["dataset"]["kwargs"]["segments"]["test"]`, instead of `task["dataset"]["kwargs"]["segments"]["train"]` in line 192.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
